### PR TITLE
Fix extensions format for git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-*.ttf filter=lfs diff=lfs merge=lfs -text
-*.woff filter=lfs diff=lfs merge=lfs -text
-*.woff2 filter=lfs diff=lfs merge=lfs -text
+woff2 filter=lfs diff=lfs merge=lfs -text
+woff filter=lfs diff=lfs merge=lfs -text
+ttf filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
The gitattributes file was wrong and was causing phantom "modifications" to show up in `git status`. Fixed this by deleting the file and then running:

```
git lfs track ttf
git lfs track woff
git lfs track woff2
```
