### PR TITLE
Unpin the source-*-pro fonts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 woff2 filter=lfs diff=lfs merge=lfs -text
 woff filter=lfs diff=lfs merge=lfs -text
 ttf filter=lfs diff=lfs merge=lfs -text
+*.woff filter=lfs diff=lfs merge=lfs -text
+*.woff2 filter=lfs diff=lfs merge=lfs -text
+*.ttf filter=lfs diff=lfs merge=lfs -text
+*.eot filter=lfs diff=lfs merge=lfs -text
+*.otf filter=lfs diff=lfs merge=lfs -text

--- a/fonts/source-code-pro/LICENSE.txt
+++ b/fonts/source-code-pro/LICENSE.txt
@@ -1,0 +1,93 @@
+Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/fonts/source-code-pro/OTF/SourceCodePro-Black.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-Black.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e5aa06e572b58f746d1ec9b67b13081f10a18e330e546c960c2124c0262be99
+size 144272

--- a/fonts/source-code-pro/OTF/SourceCodePro-BlackIt.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-BlackIt.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b5a08844e41c1e639599a32460cc05e74a19829cd38c17ec12ff1cdf072c8ec
+size 122048

--- a/fonts/source-code-pro/OTF/SourceCodePro-Bold.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-Bold.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef5f4c7caf474cefbe73831bf76910a72e3a2507519bb281d66eba778a6f193d
+size 143932

--- a/fonts/source-code-pro/OTF/SourceCodePro-BoldIt.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-BoldIt.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88815d54077a519ab4d7543f1c951ac4dfdc7706da0cc7c4e86f3eaa0fa0f651
+size 120672

--- a/fonts/source-code-pro/OTF/SourceCodePro-ExtraLight.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-ExtraLight.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc13cb9f101a05254a1ce5e8cd96374c96a1d09c2a2d7e59661414f35728f968
+size 136572

--- a/fonts/source-code-pro/OTF/SourceCodePro-ExtraLightIt.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-ExtraLightIt.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71d8bfd458e567be7a2c9f4ea52a4dc7a2a99927ae59864c1cb150f89b0fb7b6
+size 117868

--- a/fonts/source-code-pro/OTF/SourceCodePro-It.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-It.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e47642fc0cff14647ac6f67b285e7bec054f7b5d1300adcc21ddcbb404d0cc0
+size 120036

--- a/fonts/source-code-pro/OTF/SourceCodePro-Light.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-Light.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19b0f8a69e40266c22c52923995ca63dcaa4c3fadb5569f080755fded5f7a278
+size 139120

--- a/fonts/source-code-pro/OTF/SourceCodePro-LightIt.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-LightIt.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf1422b18581460bb648813690bd6240fdd74e56a2389e328088686d2fe8a66a
+size 120972

--- a/fonts/source-code-pro/OTF/SourceCodePro-Medium.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-Medium.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48473cbb0569945196f5d25e4ac84de7346a013aa5dae44385feb880dca56e4e
+size 140444

--- a/fonts/source-code-pro/OTF/SourceCodePro-MediumIt.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-MediumIt.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be7be4954a0abca187a7bc8df57794d8b944d57cc5567ed85b2c7fdea06f39b2
+size 120308

--- a/fonts/source-code-pro/OTF/SourceCodePro-Regular.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-Regular.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e41bf2651da5cea37961c9476ee457d47d0b889007941c2fab4c815732772ec
+size 140088

--- a/fonts/source-code-pro/OTF/SourceCodePro-Semibold.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-Semibold.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80a6ac083d543064858e4c2f286872fb8d35ed6753c1dc4c24ff6965fc783d94
+size 141308

--- a/fonts/source-code-pro/OTF/SourceCodePro-SemiboldIt.otf
+++ b/fonts/source-code-pro/OTF/SourceCodePro-SemiboldIt.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a64c80402179d8cb35bf6ace4175aead3707fbbf25f4d2e601d838a9bface113
+size 120360

--- a/fonts/source-code-pro/README.md
+++ b/fonts/source-code-pro/README.md
@@ -1,0 +1,11 @@
+# Source Code Pro
+
+Vendorized version of Source Code Pro
+
+Changes:
+
+* EOT font removed (not supporting old IE)
+
+## Further information
+
+For information about the design and background of Source Code, please refer to the [official font readme file](http://www.adobe.com/products/type/font-information/source-code-pro-readme.html).

--- a/fonts/source-code-pro/TTF/SourceCodePro-Black.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-Black.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78cb41c499fe3c749633c3481f414ed85df9b518b45cec10e3aa4a9d31217e58
+size 197024

--- a/fonts/source-code-pro/TTF/SourceCodePro-BlackIt.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-BlackIt.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b52ef9cab7758aa2ef1d65916d4922cff40d0ecd15dc68d1d011875acaa79c4
+size 163116

--- a/fonts/source-code-pro/TTF/SourceCodePro-Bold.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-Bold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72f35788b9ed009b4f2e9c947447e6b31fbdd00bb8d583e5675660a0e2bc40dd
+size 197004

--- a/fonts/source-code-pro/TTF/SourceCodePro-BoldIt.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-BoldIt.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b242cf3324b3b6fd268bb98aedb6fd1c4ba47e09cd72cc9380fb68de524462a9
+size 162976

--- a/fonts/source-code-pro/TTF/SourceCodePro-ExtraLight.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-ExtraLight.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d49a0c6fb6eea82cc25c2a9010615d623dfc460a631608bad9aa9bb02488b023
+size 198988

--- a/fonts/source-code-pro/TTF/SourceCodePro-ExtraLightIt.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-ExtraLightIt.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a1800635b8486bbd877ba0c7efe300391a44ec713f44c7c87725b8c24064267
+size 165008

--- a/fonts/source-code-pro/TTF/SourceCodePro-It.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-It.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04c0fb338201c9fed2821176461165d27cf70182bdb9aa47ffb75e1ddfcf54cc
+size 163624

--- a/fonts/source-code-pro/TTF/SourceCodePro-Light.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-Light.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87e62c610e5772d2098a8a3d3604cef2f63487e9b61a37352510c6199372b163
+size 198696

--- a/fonts/source-code-pro/TTF/SourceCodePro-LightIt.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-LightIt.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a794a0af2cb80a518aee10f394f5cfa1172587ce097ce01a0d0edc774c159ea5
+size 164852

--- a/fonts/source-code-pro/TTF/SourceCodePro-Medium.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-Medium.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8d35a748a3b27e5d8b13d56445ef4c2fa56d66386b4ff95024639f8fe798e6b
+size 197064

--- a/fonts/source-code-pro/TTF/SourceCodePro-MediumIt.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-MediumIt.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c65aa972c2d9a79f791032a662b6c87bf9d4ab7559331865e449addaa0045c1d
+size 163436

--- a/fonts/source-code-pro/TTF/SourceCodePro-Regular.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-Regular.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef6ea62b6849bc1535aae941d32de8d7b3ad14eab87d681dd237d125e36aebec
+size 197644

--- a/fonts/source-code-pro/TTF/SourceCodePro-Semibold.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-Semibold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:597f7605b53a1b4be42ebfb9bf7bb4ff99154ed080e13307eb5f046474aae072
+size 196576

--- a/fonts/source-code-pro/TTF/SourceCodePro-SemiboldIt.ttf
+++ b/fonts/source-code-pro/TTF/SourceCodePro-SemiboldIt.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b08e44c592d9817302a0cd59b7998aa50698456c251d1b292e86b1cd84e0adc3
+size 163376

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Black.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Black.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fd8c22b1aef9e081accbfa2c210dd106a369c9eada45e403fb45e64e448324b
+size 89940

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-BlackIt.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-BlackIt.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ffbc4a9e8620647770124d55ff904b1c62af8269bc1af829acb48f8cb1b7ea9
+size 76568

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Bold.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Bold.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63bfbe3f5157098e8da8301336c4244860e11f24269fbd7f3d22d5c8efba693c
+size 90556

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-BoldIt.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-BoldIt.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef7b64f200f9d4922a0c1223a699953f678dedfc5d4a957c211a0f5a60efea17
+size 76360

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-ExtraLight.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-ExtraLight.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75bb452d91808f1b22845dd7eea3a09829221778f7dfc0bb7ca788311bc8d1e4
+size 83528

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-ExtraLightIt.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-ExtraLightIt.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b63c6261b856ee1b08926236e155f84c4379228e4036575e93bb42a556181604
+size 72700

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-It.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-It.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eaad8961cb926b05aef298c3cfb9d9031dc8250c355e4496d1b12bb96130e57
+size 76372

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Light.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Light.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b098db31a44dd64f8c009bad051277fd3ea463d43fe759215cbcaf9c4f968bcf
+size 87828

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-LightIt.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-LightIt.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f61ff9a5bd1c52f65ee64e6ae079f90da7b1af99d1eeea8b824a850f0b405ca
+size 75532

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Medium.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Medium.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:809e4e1f297e3b9a78f9e969038430390789da84e52137b4ef979604ab96f420
+size 89400

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-MediumIt.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-MediumIt.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53328cbf519594365345283c594451133a7da4d8d2cdbf2b435c0ac94d597b69
+size 76732

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Regular.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Regular.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e1f9ae42a2d0415b81f7fe47aa98f56918a51effb0ab150557ce7fab352de9d
+size 89024

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Semibold.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-Semibold.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3200fd0097d1546007a7a22ccae78a3ef9fbfe7b73c5c50f8c229c1fdfc2448
+size 89616

--- a/fonts/source-code-pro/WOFF/OTF/SourceCodePro-SemiboldIt.otf.woff
+++ b/fonts/source-code-pro/WOFF/OTF/SourceCodePro-SemiboldIt.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e3c631f8a94cb6683f4a50df1c4f2a12cfdee88fac21bf2cd2d3132d039bd54
+size 76324

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Black.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Black.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bd4d1e63fa7583b4bada155a720915e5947b16df23c13c3a7ae6d86fad972cf
+size 87528

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-BlackIt.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-BlackIt.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:848d6ebc209e34e5b3583f39c492e71a65d14c0e2d196a02b2abd5c334a754ce
+size 75556

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Bold.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Bold.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecaa23393162b6d08a13c6c4ae020b5d8bff2c9472bd856f3a3a671a4d6b1820
+size 89188

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-BoldIt.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-BoldIt.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91363969f06c859e8f6f83b870985b3c0d7287c3e9039907a61204c7b6ee1f44
+size 76748

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-ExtraLight.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-ExtraLight.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce7652796d558712a653f31fa0b684fcfebfd6bb443eb007c6698eacd75dc6ac
+size 87952

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-ExtraLightIt.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-ExtraLightIt.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87fb71f95ab2deabb2b893d8de7c99ed5bd2a343b2e0317b627e855948dde969
+size 75216

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-It.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-It.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4509bda24976b1061b5b1e6cd3df6cc1459ff231a38d8ea4b323d1034ab49b2
+size 76572

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Light.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Light.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cb143b90773c80443b62f06331c5e07673a79bb8602427c323019d15b3053c5
+size 89820

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-LightIt.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-LightIt.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e651edeb15a68ca27bcc81cb734d3ebeb0e7f31c77db04c3b55d07eb204a835
+size 77152

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Medium.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Medium.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21adb9feb3720cd81040010a267953c58b810a70522efefa0f3d9c9e2e5cb485
+size 89448

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-MediumIt.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-MediumIt.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef46dc2f24d08e501e16d6ac072208caa3b0be9e9a1b73bdf081bb758b6ddb92
+size 76592

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Regular.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Regular.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c86753a63486caa70138bb1e9d687cc2b4712853a61d0f46cf893d9f2abecc35
+size 89604

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Semibold.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-Semibold.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0a9d2215b686b16884a109b745d4aa3825a673f8d533b9ad6958132e26c7f56
+size 89232

--- a/fonts/source-code-pro/WOFF/TTF/SourceCodePro-SemiboldIt.ttf.woff
+++ b/fonts/source-code-pro/WOFF/TTF/SourceCodePro-SemiboldIt.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ce31d1cc13efae23d974c42c24610061eb8e9b9132f8016584f237b1217b3bc
+size 76776

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Black.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Black.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e44946853189c99b02805f262f80ad585a38f9fd8230032a38c2223ac04814f8
+size 75476

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-BlackIt.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-BlackIt.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de7aba229512ca110fd7bb9ddcf00b01f6d276d74d4158bdd9f15959cd4a118a
+size 65164

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Bold.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Bold.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:799289b1337dc7b230af74a8309d6d70009fd77b2456ac60c5bc7220d00de8e5
+size 77136

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-BoldIt.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-BoldIt.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbb687e037a9f7353d08db95d5a6d7e3a8b2464f9aeec8c9aef9f9e7c8f17dfa
+size 65316

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-ExtraLight.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-ExtraLight.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c6ae6041e0996846b5a3c0f208c677175f4a5b2d5cf881a72682b637ac2b16c
+size 71172

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-ExtraLightIt.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-ExtraLightIt.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:842a03dc3b61aa01ff891f915ae741a89304a8533ccbc9fbbbbfdb5ac2b60ab3
+size 61608

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-It.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-It.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa5c9dee3af0898d909c55f73b3ad56d93fea2d9dec4a4f4f50160cc13a31a99
+size 64784

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Light.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Light.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17ffc606b93916ab175ebb29f5826f58e47b68358928474381cb9ea712c851c1
+size 74664

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-LightIt.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-LightIt.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d786ef256ff27588fc0d2775f8f25901c12ef5b166229dcb4c1e572f6f408b1
+size 64508

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Medium.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Medium.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e41275bd16da2028442bedcbb224d53e308b02f50be0d31889beff3f73bb019e
+size 76108

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-MediumIt.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-MediumIt.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4734aa36af752a05b325e6c5369a4fdfb2c72c8ce16059940ac287162f618590
+size 65268

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Regular.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Regular.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c46c8f88e55d20799239a5a486e794a8a678b09fb181b34cbd587567ab7eb88
+size 76256

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Semibold.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-Semibold.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b74bfecf9ecd69cff4b99516cb326106fe91e5ae5a40b98de6a639b17f6287f
+size 76348

--- a/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-SemiboldIt.otf.woff2
+++ b/fonts/source-code-pro/WOFF2/OTF/SourceCodePro-SemiboldIt.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33d6c000e0cee05626a9429b2adba9ee3fff58d43bfd9ae4a4c50fad3089cda8
+size 65208

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Black.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Black.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e4da45635efb6baac49e8ab51e3ac00d1b10c7b9891c810ca3ad13a5cce0209
+size 63856

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-BlackIt.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-BlackIt.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcbe08a784b436b0ce92680383e5c1309ac925a2e62aa9acb2e7c438c016cf10
+size 54168

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Bold.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Bold.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:237c18393385ac83d7ff472e8b5cc7c8237d76185ed12462e8712653222efe02
+size 65028

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-BoldIt.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-BoldIt.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:194dd9ffc9e5fe7d92a02fda5268fd0a30a2aaf2d88991e698c335d20ca666a6
+size 55488

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-ExtraLight.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-ExtraLight.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a59095a98ceb04a650bb97f7940b50827ee77d31d0c2ac94d1d35a3176ceaf85
+size 63476

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-ExtraLightIt.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-ExtraLightIt.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a3c99a63fb9c0474c9e93309bf2d092f2d5b5ce10f4690ef1835a9f057d6fc8
+size 53712

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-It.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-It.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:684b6d3794ad638c8cef73c9949cd55d76b586e66f54c5d9cc263932ad5e5d14
+size 55172

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Light.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Light.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed752236b64765bc64641f85afd2dd56b57e6cb321c7210eae20b04b6852db1d
+size 65188

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-LightIt.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-LightIt.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d98155bc987e5b9f69c3c56ef730ed1ed60fb15385eaefd47f68421178cdedd2
+size 55580

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Medium.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Medium.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b8d13e4b7346500a4f131a70f538ead645a76be15ddb8c97bd47b1477bb3baf
+size 64824

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-MediumIt.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-MediumIt.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00b5f307fbe02c8791aab3ce82b9f2ea342f572924a0d88eda717ae8e4e405e6
+size 55012

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Regular.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Regular.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:767e20b59ccab0029a12b61c9873722823e75f871f008ed659269e1939dc0261
+size 64948

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Semibold.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-Semibold.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9deaeeb1bb504eb45d4bd38f1f710e7727a60a4d07534036f76dc4fdbf009c8
+size 64708

--- a/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-SemiboldIt.ttf.woff2
+++ b/fonts/source-code-pro/WOFF2/TTF/SourceCodePro-SemiboldIt.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:751d18714381542c83a826b8dee07e6bf57a7a9032f2fae8893537ebcaef669b
+size 55260

--- a/fonts/source-code-pro/source-code-pro.css
+++ b/fonts/source-code-pro/source-code-pro.css
@@ -1,0 +1,153 @@
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 200;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-ExtraLight.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-ExtraLight.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-ExtraLight.otf') format('opentype'),
+         url('TTF/SourceCodePro-ExtraLight.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 200;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-ExtraLightIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-ExtraLightIt.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-ExtraLightIt.otf') format('opentype'),
+         url('TTF/SourceCodePro-ExtraLightIt.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 300;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-Light.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-Light.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-Light.otf') format('opentype'),
+         url('TTF/SourceCodePro-Light.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 300;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-LightIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-LightIt.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-LightIt.otf') format('opentype'),
+         url('TTF/SourceCodePro-LightIt.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 400;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-Regular.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-Regular.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-Regular.otf') format('opentype'),
+         url('TTF/SourceCodePro-Regular.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 400;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-It.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-It.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-It.otf') format('opentype'),
+         url('TTF/SourceCodePro-It.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 500;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-Medium.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-Medium.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-Medium.otf') format('opentype'),
+         url('TTF/SourceCodePro-Medium.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 500;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-MediumIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-MediumIt.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-MediumIt.otf') format('opentype'),
+         url('TTF/SourceCodePro-MediumIt.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 600;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-Semibold.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-Semibold.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-Semibold.otf') format('opentype'),
+         url('TTF/SourceCodePro-Semibold.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 600;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-SemiboldIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-SemiboldIt.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-SemiboldIt.otf') format('opentype'),
+         url('TTF/SourceCodePro-SemiboldIt.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 700;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-Bold.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-Bold.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-Bold.otf') format('opentype'),
+         url('TTF/SourceCodePro-Bold.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 700;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-BoldIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-BoldIt.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-BoldIt.otf') format('opentype'),
+         url('TTF/SourceCodePro-BoldIt.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 900;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-Black.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-Black.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-Black.otf') format('opentype'),
+         url('TTF/SourceCodePro-Black.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Code Pro';
+    font-weight: 900;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceCodePro-BlackIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceCodePro-BlackIt.otf.woff') format('woff'),
+         url('OTF/SourceCodePro-BlackIt.otf') format('opentype'),
+         url('TTF/SourceCodePro-BlackIt.ttf') format('truetype');
+}

--- a/fonts/source-sans-pro/LICENSE.txt
+++ b/fonts/source-sans-pro/LICENSE.txt
@@ -1,0 +1,93 @@
+Copyright 2010, 2012, 2014 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of Adobe Systems Incorporated in the United States and/or other countries.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/fonts/source-sans-pro/OTF/SourceSansPro-Black.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-Black.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e447cd47a62874dc94d6ab97a84dbeb7f2f0aba3e490b9f0128b6c8399a96f37
+size 234176

--- a/fonts/source-sans-pro/OTF/SourceSansPro-BlackIt.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-BlackIt.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07198d116759bd75afeee9f7a975c9435608fa57e0647a09349c9d01b90ea3d0
+size 81120

--- a/fonts/source-sans-pro/OTF/SourceSansPro-Bold.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-Bold.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b8bd174f97413334e317be808d14d0ff8f6efed79a69299d84384c7e10e9312
+size 235128

--- a/fonts/source-sans-pro/OTF/SourceSansPro-BoldIt.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-BoldIt.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b94666879fb221aad70f479107ad01f8c93500c6fd2a77811da412d364441ab5
+size 80392

--- a/fonts/source-sans-pro/OTF/SourceSansPro-ExtraLight.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-ExtraLight.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:faccddbb11292f3952d38248a02087856ea4b1ec61f2828f2e6018d051127a98
+size 221580

--- a/fonts/source-sans-pro/OTF/SourceSansPro-ExtraLightIt.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-ExtraLightIt.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06ec3606be288627b452595d25e46e2c5094ef453e2f5c371076390557c53495
+size 76400

--- a/fonts/source-sans-pro/OTF/SourceSansPro-It.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-It.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e90b35e5f96577f03a27e659c4b69666e45e1691f2bce2fc2f883aeff9238419
+size 79724

--- a/fonts/source-sans-pro/OTF/SourceSansPro-Light.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-Light.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b3250ffc8182e93d79221c36b8f6a214600f7082b843142ef9c252581e13bb6
+size 226032

--- a/fonts/source-sans-pro/OTF/SourceSansPro-LightIt.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-LightIt.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5dc9a7de549b032e341b4564ef9f8f215ab938f9adcec36442de5f9a7bb0290
+size 77816

--- a/fonts/source-sans-pro/OTF/SourceSansPro-Regular.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-Regular.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b096b47206d8f78a2c49af2f2ae46b35d93b0e3cf105a9febef59144aa2eae2
+size 229588

--- a/fonts/source-sans-pro/OTF/SourceSansPro-Semibold.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-Semibold.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee3ba5c88400b22b880d85202ce82143dc5e19861bf7880b7f4c32d4263e96d5
+size 232680

--- a/fonts/source-sans-pro/OTF/SourceSansPro-SemiboldIt.otf
+++ b/fonts/source-sans-pro/OTF/SourceSansPro-SemiboldIt.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82ed41eed0b18254c1bbcd7c4317abfbfa55ac056a5cf62004f561c0c44f735c
+size 80316

--- a/fonts/source-sans-pro/README.md
+++ b/fonts/source-sans-pro/README.md
@@ -1,0 +1,11 @@
+# Source Sans Pro
+
+Vendorized version of Source Sans Pro
+
+Changes:
+
+* EOT font removed (not supporting old IE)
+
+## Further information
+
+For information about the design and background of Source Sans, please refer to the [official font readme file](http://www.adobe.com/products/type/font-information/source-sans-pro-readme.html).

--- a/fonts/source-sans-pro/TTF/SourceSansPro-Black.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-Black.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e59595ebe0445db9bcea5de0d0fa2e08766809d1c97789d938b71a77ecf3cf5
+size 289364

--- a/fonts/source-sans-pro/TTF/SourceSansPro-BlackIt.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-BlackIt.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cdaeb50edf2de3f6222f4e53e7a22e838ee9533fd67a521a24c8ad973d48a8f
+size 103404

--- a/fonts/source-sans-pro/TTF/SourceSansPro-Bold.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-Bold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2efc3a95d076f2d04c5928c0ad698b7c61cc302d6f6e79e9643cd3722f7becc2
+size 291424

--- a/fonts/source-sans-pro/TTF/SourceSansPro-BoldIt.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-BoldIt.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eab3e6c76c677dda287b2e56f41f718cc975a14150f72ef82e0a87f1b56eac4c
+size 103608

--- a/fonts/source-sans-pro/TTF/SourceSansPro-ExtraLight.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-ExtraLight.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8575fc5a5e9e9e4fe67e0b2936d48e83d6f2fb627e4f4f1308c2a64c0bbc7436
+size 291652

--- a/fonts/source-sans-pro/TTF/SourceSansPro-ExtraLightIt.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-ExtraLightIt.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bc32fe1b83607564ad87b4171d3db6f862ea6345a22a3a1294802d7fb4eabe8
+size 104768

--- a/fonts/source-sans-pro/TTF/SourceSansPro-It.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-It.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36133e9f508b0b4c639e84b2a09855350be0b13700ad729ab519aa78e5c48d20
+size 104236

--- a/fonts/source-sans-pro/TTF/SourceSansPro-Light.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-Light.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d9cd89e3cdbcc08f95fea442b3ce366958ba30104d678e9604126e5fd2565d8
+size 293220

--- a/fonts/source-sans-pro/TTF/SourceSansPro-LightIt.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-LightIt.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eddb7a3959bde6d9cd0b81df670f8cf40c6ff5ef77e6ea9d44960ce29bf0b7d
+size 104616

--- a/fonts/source-sans-pro/TTF/SourceSansPro-Regular.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-Regular.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b77f3a700edd0fc0dec73258f882d5c3926c77f5caf6800a201d2166568d2309
+size 293956

--- a/fonts/source-sans-pro/TTF/SourceSansPro-Semibold.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-Semibold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b440fd42fd5a54e1b252731deca9cc86604bee6ffa99281f5874c3476eb17eae
+size 292404

--- a/fonts/source-sans-pro/TTF/SourceSansPro-SemiboldIt.ttf
+++ b/fonts/source-sans-pro/TTF/SourceSansPro-SemiboldIt.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7687a5558387aa42c340012f24adc6d447f43cfaf3974e75fd91fff6451fe79
+size 104020

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-Black.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-Black.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f418a17c5e74c65aa64d5b0d2b28ef01415406a05d72f0b0ec71f789a1c531f
+size 121420

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-BlackIt.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-BlackIt.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b57bc11565afbe5c5584d55a6f11dc98cc1db5961d177bb9bfcfc4d51a228cb5
+size 50592

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-Bold.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-Bold.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7de8582bfa70bfc9474928687649c6efb6dc990fab02a7820d0b9b522c7edea1
+size 124508

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-BoldIt.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-BoldIt.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b25e303ff2efb65bdd852e0b035a896df8bb0b93f293e891156693dfefc1875
+size 50708

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-ExtraLight.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-ExtraLight.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:614ac4b42b8060b9d348af2cf20afe5a77833e4580e5f5f1546fbc12ed6a8c95
+size 113168

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-ExtraLightIt.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-ExtraLightIt.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e4044826a0254c6cbc654101f90fa1eb22bc5c115241a175f247d86a5638bd3
+size 46812

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-It.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-It.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3429452d51113fbdaf6e1278905f7481bca2040b7d4a8a6dccac0889ba0d19e7
+size 50556

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-Light.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-Light.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bad2e26702eceba676342679bcdd5a6ed966b10c29e82417ea6b6d5b77ec4006
+size 119280

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-LightIt.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-LightIt.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ae6bc531817f169fd03e48790713d3355259808aca34e812dc54c8e72e48738
+size 48956

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-Regular.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-Regular.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34beb8307459d04719789002534a6749e1b7a40021de510bebcbc550d6507006
+size 121876

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-Semibold.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-Semibold.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d67491007d9aa13f3f4e1b04866ec2d3177c5011d8aaea50145f803b1410a35
+size 123400

--- a/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-SemiboldIt.otf.woff
+++ b/fonts/source-sans-pro/WOFF/OTF/SourceSansPro-SemiboldIt.otf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2eabdcc6b5e3434d9ac76b12e7d8fcfd67a358c6168b251e31e68924d424c6e8
+size 50616

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-Black.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-Black.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b420de355e205983fae5a90d1ca278491fd6e0613e0e5f3a2c4cbc1de20768e5
+size 113800

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-BlackIt.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-BlackIt.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62038fd56759a7af4e16163cc12cdfd4f944e69a2b8dc846d6453741d8ac5356
+size 49704

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-Bold.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-Bold.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57fb1f7f5ac0cc6b1ba09c70b762524eff720df9dd678c11924bb4978a7e0085
+size 117872

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-BoldIt.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-BoldIt.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38cebeb6329ef5a23c4487e7e132aeb96c628237de9df7e054b7a34df584e579
+size 50608

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-ExtraLight.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-ExtraLight.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54b0fb6a43b7eca63e8c8c596afa696b033cf86c71771a7d467ce97403dab0d9
+size 114336

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-ExtraLightIt.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-ExtraLightIt.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d2c95a58cae5dd7e21384270d756c3eb87609ed37df35c12ae6b516be8cf5a0
+size 49684

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-It.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-It.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4b06a8fc6dd7089f14844eb5a46c9048dad81b47187bf40e4fa89da4aae9fb9
+size 51012

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-Light.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-Light.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3703c43c798f137e5e38f8dc60cafb761cc792f85fcbbc60148eae0cd165a5e8
+size 118284

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-LightIt.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-LightIt.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c6dfb6a3772c9647e8be3315222e3731fe6f08c98fc1bb2548c0502b1cd407e
+size 50992

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-Regular.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-Regular.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ab72d9ee658b0ee28c414ecf5a304421a14f1bdb585ab17c034c037cd215ab7
+size 119064

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-Semibold.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-Semibold.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:063e7b1ecf947f422a490ecd3bc2440095e55b371d781f9f93fae340e2d6caad
+size 118412

--- a/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-SemiboldIt.ttf.woff
+++ b/fonts/source-sans-pro/WOFF/TTF/SourceSansPro-SemiboldIt.ttf.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03ffb41ed1ea5f6830812d3da141ba09798dac381e3d8b226c26f4cd1f2d08b6
+size 50924

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-Black.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-Black.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5eacdb6ce7bb56fd666cb4cd89378c1560e44c1481b56cc51e835f99574390fe
+size 100624

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-BlackIt.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-BlackIt.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2d0f8d70cc3ec0d83e201b1b279ea7125a8fdda1837e9ed6dc6fef953026f14
+size 41480

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-Bold.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-Bold.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a0b54f282e008455908284f30f8ffb89805fcfe4842ab6ef193bc0e74d621b4
+size 103484

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-BoldIt.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-BoldIt.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4938d534c8f55a0752e7fe41ba837dd9132b0672cfc6f5e3cfa857ccfca82b99
+size 41808

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-ExtraLight.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-ExtraLight.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f68e45f4a88c13694a38ffb6b926894fed680a34e166c4674a5c7e181d28104d
+size 94272

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-ExtraLightIt.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-ExtraLightIt.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f864887637027c221c197bfd48b4e57e55d1191374f3054f5de0f828f7ef93
+size 38136

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-It.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-It.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c27c86b08c072f4277da501507178795930c4d001bdba10c36bc26ef93e28080
+size 42084

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-Light.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-Light.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abe8d15ab9271aa4e208934593f6ddab7b87a820c7e5dc53122332dd5a46c140
+size 99500

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-LightIt.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-LightIt.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9264363a682a9a5d3f44a90f74218513752217fdca96006981b380026bb2797f
+size 40388

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-Regular.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-Regular.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4eadfb32b2464715bb6c4878893cdbf3dfae0bd5fef4eeb63680bf3111d967b
+size 102552

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-Semibold.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-Semibold.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e82bcc30d51744b2de28618535323dd57bc929de0e5bf68df82477cbac7dfcb8
+size 103132

--- a/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-SemiboldIt.otf.woff2
+++ b/fonts/source-sans-pro/WOFF2/OTF/SourceSansPro-SemiboldIt.otf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daafb9bb90be56e0b097c84f1e0361d511f234d8be77b814cc169324eb239f3d
+size 41976

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-Black.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-Black.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc1ee781508ebbae00d923c7fc67fc8c04d1245a2550792f64063a41872044ed
+size 82052

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-BlackIt.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-BlackIt.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb4427a404e8e0b3efe534d42ce57befd17f37a8f43092424a0696fbef3e03c4
+size 34812

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-Bold.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-Bold.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:929f75e2093d43828eaaa71f7e3a08646e7291c9ba076bda3fa566bcbd804735
+size 85604

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-BoldIt.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-BoldIt.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c74338e0926f728381decac0de1d8c1d302f65a1ec09b8fa4577e81b1abfd82
+size 35864

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-ExtraLight.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-ExtraLight.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da6ec4a92397070016a8c5d2fe4a906bae663857ae1f7d9712886b0aa57df408
+size 82808

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-ExtraLightIt.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-ExtraLightIt.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae923ae9762ac4027575aeb9cc629fb745ee402a2aa454cab6e4e80f490e0391
+size 34560

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-It.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-It.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b72a7eb820405438765bd48f8f260bfc06af13ed3aac5a221373939a57041265
+size 36016

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-Light.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-Light.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:019ca37a258e1ee9942c9c733a3193171b651931a02527b836e3644b9fdd7c12
+size 86336

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-LightIt.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-LightIt.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93992fb418feaeb953aa65029987a4190a15ef898afaf5f265b89e49160c6f9e
+size 35952

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-Regular.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-Regular.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27c06ca531d01f12d9e28d869000985e4cf84dd0724afe578e942d44f09d19c2
+size 86844

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-Semibold.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-Semibold.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b96f55ccea2c4ad959ca841fa881a893e7df33a2e575d621a81d2f1063b429c4
+size 86196

--- a/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-SemiboldIt.ttf.woff2
+++ b/fonts/source-sans-pro/WOFF2/TTF/SourceSansPro-SemiboldIt.ttf.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21614f1d491479de030e93a847683612445af064396d59e199b808028a644fd7
+size 35984

--- a/fonts/source-sans-pro/source-sans-pro.css
+++ b/fonts/source-sans-pro/source-sans-pro.css
@@ -1,0 +1,131 @@
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 200;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-ExtraLight.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-ExtraLight.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-ExtraLight.otf') format('opentype'),
+         url('TTF/SourceSansPro-ExtraLight.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 200;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-ExtraLightIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-ExtraLightIt.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-ExtraLightIt.otf') format('opentype'),
+         url('TTF/SourceSansPro-ExtraLightIt.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 300;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-Light.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-Light.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-Light.otf') format('opentype'),
+         url('TTF/SourceSansPro-Light.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 300;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-LightIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-LightIt.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-LightIt.otf') format('opentype'),
+         url('TTF/SourceSansPro-LightIt.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-Regular.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-Regular.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-Regular.otf') format('opentype'),
+         url('TTF/SourceSansPro-Regular.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 400;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-It.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-It.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-It.otf') format('opentype'),
+         url('TTF/SourceSansPro-It.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-Semibold.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-Semibold.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-Semibold.otf') format('opentype'),
+         url('TTF/SourceSansPro-Semibold.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 600;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-SemiboldIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-SemiboldIt.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-SemiboldIt.otf') format('opentype'),
+         url('TTF/SourceSansPro-SemiboldIt.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 700;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-Bold.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-Bold.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-Bold.otf') format('opentype'),
+         url('TTF/SourceSansPro-Bold.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 700;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-BoldIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-BoldIt.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-BoldIt.otf') format('opentype'),
+         url('TTF/SourceSansPro-BoldIt.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 900;
+    font-style: normal;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-Black.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-Black.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-Black.otf') format('opentype'),
+         url('TTF/SourceSansPro-Black.ttf') format('truetype');
+}
+
+@font-face{
+    font-family: 'Source Sans Pro';
+    font-weight: 900;
+    font-style: italic;
+    font-stretch: normal;
+    src: url('WOFF2/TTF/SourceSansPro-BlackIt.ttf.woff2') format('woff2'),
+         url('WOFF/OTF/SourceSansPro-BlackIt.otf.woff') format('woff'),
+         url('OTF/SourceSansPro-BlackIt.otf') format('opentype'),
+         url('TTF/SourceSansPro-BlackIt.ttf') format('truetype');
+}

--- a/package.json
+++ b/package.json
@@ -20,9 +20,5 @@
   "bugs": {
     "url": "https://github.com/nteract/assets/issues"
   },
-  "homepage": "https://github.com/nteract/assets#readme",
-  "dependencies": {
-    "source-code-pro": "git://github.com/adobe-fonts/source-code-pro.git#release",
-    "source-sans-pro": "git://github.com/adobe-fonts/source-sans-pro.git#release"
-  }
+  "homepage": "https://github.com/nteract/assets#readme"
 }


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/308.

We can also trim this down even more because we really only need the WOFF2 font since we're on Chromium/Electron with these assets. I'm ok with making this work as is for now and refining with a trimmed down published copy after.
