### PR TITLE
chore(entry): should be no entry point in assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "nteract-assets",
   "version": "2.0.0",
   "description": "Static assets used in nteract/nteract",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nteract/assets.git"


### PR DESCRIPTION
When trying to set up `flow-typed` with `nteract-assets`, this error comes up:

```
~/code/src/github.com/nteract/nteract$ flow-typed install
• Found flow-bin@v0.33.0 installed. Installing libdefs compatible with this version of Flow...
• Found 72 dependencies in package.json. Searching for libdefs...
• flow-typed cache not found, fetching from GitHub...done.
• Installing 7 libdefs...
  • moment_v2.x.x.js
    └> ./flow-typed/npm/moment_v2.x.x.js
  • react-dnd-html5-backend_v2.1.x.js
    └> ./flow-typed/npm/react-dnd-html5-backend_v2.1.x.js
  • react-dnd_v2.x.x.js
    └> ./flow-typed/npm/react-dnd_v2.x.x.js
  • react-redux_v4.x.x.js
    └> ./flow-typed/npm/react-redux_v4.x.x.js
  • enzyme_v2.x.x.js
    └> ./flow-typed/npm/enzyme_v2.x.x.js
  • redux_v3.x.x.js
    └> ./flow-typed/npm/redux_v3.x.x.js
  • react-addons-test-utils_v15.x.x.js
    └> ./flow-typed/npm/react-addons-test-utils_v15.x.x.js
UNCAUGHT ERROR: Error: Cannot find module 'nteract-assets' from '/Users/kylek/code/src/github.com/nteract/nteract'
    at /Users/kylek/.nvm/versions/node/v6.7.0/lib/node_modules/flow-typed/node_modules/resolve/lib/async.js:46:17
    at process (/Users/kylek/.nvm/versions/node/v6.7.0/lib/node_modules/flow-typed/node_modules/resolve/lib/async.js:173:43)
    at ondir (/Users/kylek/.nvm/versions/node/v6.7.0/lib/node_modules/flow-typed/node_modules/resolve/lib/async.js:188:17)
    at load (/Users/kylek/.nvm/versions/node/v6.7.0/lib/node_modules/flow-typed/node_modules/resolve/lib/async.js:69:43)
    at onex (/Users/kylek/.nvm/versions/node/v6.7.0/lib/node_modules/flow-typed/node_modules/resolve/lib/async.js:92:31)
    at /Users/kylek/.nvm/versions/node/v6.7.0/lib/node_modules/flow-typed/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:123:15)
```

This is because we have an entrypoint on this package even though we don't have an index.js.
